### PR TITLE
fix devices not properly deactivated

### DIFF
--- a/QControlComponent.py
+++ b/QControlComponent.py
@@ -72,10 +72,10 @@ class QControlComponent(BaseComponent):
 
         self._shift_pressed = False
         self._shift_fixed = False
-        self._control_layer_1 = False  # track control
-        self._control_layer_2 = False  # song control
-        self._control_layer_3 = False  # clip launch
-        self._layer_onetrack = False  # clip launch
+        self._control_layer_1 = False  # mix
+        self._control_layer_2 = False  # control
+        self._control_layer_3 = False  # launch
+        self._layer_onetrack = False  # launch (onetrack)
         self._sequencer = False  # sequencer
 
         # do this before initializing the sequencer!
@@ -829,8 +829,9 @@ class QControlComponent(BaseComponent):
                 if hasattr(self, "QSequencer"):
                     self.QSequencer.remove_handler()
 
-            # activate device controls for the layers (encoder 1-4 and 9-12)
-            if layer in ["_control_layer_2", "_control_layer_3", "_shift_fixed"]:
+            # activate device controls for the control-layer and the shift-fixed layer
+            # (encoder 1-4 and 9-12)
+            if layer in ["_control_layer_2", "_shift_fixed"]:
                 self._parent._device.set_enabled(True)
             else:
                 self._parent._device.set_enabled(False)
@@ -1998,10 +1999,11 @@ class QControlComponent(BaseComponent):
             for key, val in self.layer_listener.items():
                 getattr(self, "_remove" + val)()
 
+            # remove value listeners from buttons in case shift is released
+            # (so that we can play instruments if shift is not pressed)
+            self._parent._device.set_enabled(False)
+
             if not self._shift_pressed:
-                # remove value listeners from buttons in case shift is released
-                # (so that we can play instruments if shift is not pressed)
-                self._parent._device.set_enabled(False)
                 self._remove_handler()
                 self._parent._deactivate_control_mode()
                 # transpose notes back to last set transpose-val

--- a/QSequencer.py
+++ b/QSequencer.py
@@ -642,9 +642,13 @@ class QSequencer(object):
                 # take only first 6 characters (e.b.   "1/64_Q" )
                 self.sequence_length = self.sequence_names_inverted[self.clip.name[:6]]
                 self._parent._parent.show_message(
-                    f"sequence tempo set to {simplify_fraction(self.sequence_length , 16)} beats"
+                    "sequence tempo set to:     "
+                    + f"{simplify_fraction(self.sequence_length, self.n_notes * 4)} BARS "
                 )
-            except IndexError:
+            except KeyError:
+                self._parent._parent.show_message(
+                    "sequence tempo could not be parsed from clip-name..."
+                )
                 pass
 
     def init_sequence(self):


### PR DESCRIPTION
- fix deactivtion of device controls
   (e.g. encoders were still controlling devices even if layer was already deactivated)
- fix info-message for MIDI sequence tempo
  (catch error and indicate that tempo could not be parsed if clip-name is not properly set)